### PR TITLE
pass response instead of mutable params

### DIFF
--- a/pyfc4/models.py
+++ b/pyfc4/models.py
@@ -692,9 +692,7 @@ class Resource(object):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 		rdf_prefixes_mixins (dict): optional rdf prefixes and namespaces
 	'''
 	
@@ -710,7 +708,7 @@ class Resource(object):
 		# parse uri with parse_uri() from repo instance
 		self.uri = self.repo.parse_uri(uri)
 		
-		# HTTP
+		# parse response
 
 		# if response provided, parse and set to attributes
 		if response:
@@ -1563,9 +1561,7 @@ class NonRDFSource(Resource):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 	
 	def __init__(self, repo, uri=None, response=None):
@@ -1800,9 +1796,7 @@ class RDFResource(Resource):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 	
 	def __init__(self, repo, uri=None, response=None):
@@ -1829,9 +1823,7 @@ class Container(RDFResource):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 
 	def __init__(self, repo, uri=None, response=None):
@@ -1858,9 +1850,7 @@ class BasicContainer(Container):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 	
 	def __init__(self, repo, uri=None, response=None):
@@ -1886,9 +1876,7 @@ class DirectContainer(Container):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 		membershipResource (rdflib.term.URIRef): resource that will accumlate triples as children are added
 		hasMemberRelation (rdflib.term.URIRef): predicate that will be used when pointing from URI in ldp:membershipResource to children
 	'''
@@ -1928,9 +1916,7 @@ class IndirectContainer(Container):
 	Args:
 		repo (Repository): instance of Repository class
 		uri (rdflib.term.URIRef,str): input URI
-		data (): passed from sub-classes
-		headers (dict): passed from sub-classes
-		status_code (int): passed from sub-classes
+		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 		membershipResource (rdflib.term): resource that will accumlate triples as children are added
 		hasMemberRelation (rdflib.term): predicate that will be used when pointing from URI in ldp:membershipResource to ldp:insertedContentRelation
 		insertedContentRelation (rdflib.term): destination for ldp:hasMemberRelation from ldp:membershipResource

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -257,6 +257,38 @@ class TestBinaryUpload(object):
 		assert baz2.exists
 
 
+	# instantiate two binary resources, confirm headers don't cross-pollinate
+	def test_multiple_binary_creation(self):
+
+		'''
+		this will prepare two binary resources for upload,
+		and confirm that headers don't cross-pollinate
+		'''
+
+		# prepare first binary resource
+		rbin1 = Binary(repo, '%s/rbin1' % testing_container_uri)
+		rbin1.binary.data = 'this is test data 1'
+		rbin1.binary.mimetype = 'text/plain'
+		rbin1.create(specify_uri=True)
+		assert rbin1.exists
+
+		# prepare second, confirm that headers are empty
+		rbin2 = Binary(repo, '%s/rbin2' % testing_container_uri)
+		rbin2.binary.data = '<ele>test</ele>'
+
+		assert rbin2.headers == {}
+		assert not rbin2.binary.mimetype
+
+		# create, and confirm different data
+		rbin2.binary.mimetype = 'text/xml'
+		rbin2.create(specify_uri=True)
+
+		# get both
+		rbin1_get = repo.get_resource('%s/rbin1' % testing_container_uri)
+		rbin2_get = repo.get_resource('%s/rbin2' % testing_container_uri)
+		assert rbin1_get.binary.data.content != rbin2_get.binary.data.content
+
+
 
 class TestBasicRelationship(object):
 
@@ -625,7 +657,7 @@ class TestVersions(object):
 		assert type(baz.versions.v1) == ResourceVersion	
 
 
-# versioning
+# fixity
 class TestFixity(object):
 
 	def test_fixity_check(self):


### PR DESCRIPTION
This addresses, and closes, issue #59.  With the `headers` parameter mutable, is was changing for distinct instantiations of `NonRDFSource`, and others.

Test case added, asserting that two back-to-back created NonRDF resources do not share anything that would influence the creation.  Or anything for that matter.