### PR TITLE
merging PCDM rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ Then run:
 
 See [docs](docs) folder
 
+## Acknowledgements
+
+pyfc4 is the product of some years working with Fedora Commons 3.x, and participating in, and learning from, the greater Fedora Commons community.  Projects like [Eulfedora](https://github.com/emory-libraries/eulfedora) out of Emory University have been instrumental for inspiration and design.  Larger ecosystems like [Islandora](https://islandora.ca/) and [Samvera](https://samvera.org/) have also been invaluable for observing patterns of usage and architecture.  Big credit and thanks to these projects for sharing their code, planning documents, and everything in-between.

--- a/console.py
+++ b/console.py
@@ -41,6 +41,13 @@ fast_repo = Repository(
 	default_auto_refresh=False
 	)
 
+repo_pcdm = Repository(
+	REPO_ROOT,
+	REPO_USERNAME,
+	REPO_PASSWORD,
+	default_serialization='text/turtle',
+	custom_resource_type_parser=pcdm.custom_resource_type_parser)
+
 
 ################################################
 # Convenience Functions

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -46,6 +46,66 @@ In [3]: bc.uri # check newly created and assigned resource uri
 Out[3]: rdflib.term.URIRef('http://localhost:8080/rest/c4/a1/12/f5/c4a112f5-ab38-476c-8ebc-75b221b18300')
 ```
 
+Though each resource contains mechanisms for viewing and modifying RDF data under `self.rdf`, there is the convenience method `self.dump()` to return the raw RDF for the resource:
+```
+# default serialization is turtle (ttl)
+In [5]: print(foo.dump())
+
+@prefix dbpedia: <http://dbpedia.org/ontology/> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+@prefix fedora: <http://fedora.info/definitions/v4/repository#> .
+@prefix fedoraconfig: <http://fedora.info/definitions/v4/config#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ldp: <http://www.w3.org/ns/ldp#> .
+@prefix ore: <http://www.openarchives.org/ore/terms/> .
+@prefix pcdm: <http://pcdm.org/models#> .
+@prefix premis: <http://www.loc.gov/premis/rdf/v1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix test: <info:fedora/test/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xmlns: <http://www.w3.org/2000/xmlns/> .
+@prefix xs: <http://www.w3.org/2001/XMLSchema> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix xsi: <http://www.w3.org/2001/XMLSchema-instance> .
+
+<http://localhost:8080/rest/foo> a fedora:Container,
+        fedora:Resource,
+        ldp:Container,
+        ldp:RDFSource ;
+    fedora:created "2017-08-29T20:05:57.109000+00:00"^^xsd:dateTime ;
+    fedora:createdBy "bypassAdmin"^^xsd:string ;
+    fedora:hasParent <http://localhost:8080/rest/> ;
+    fedora:lastModified "2017-08-29T20:05:57.109000+00:00"^^xsd:dateTime ;
+    fedora:lastModifiedBy "bypassAdmin"^^xsd:string ;
+    fedora:writable true .
+
+```
+
+Optionally, provide a serialization format that python's rdflib library accepts, such as `application/rdf+xml`:
+```
+In [7]: print(foo.dump(format='application/rdf+xml'))
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:fedora="http://fedora.info/definitions/v4/repository#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <rdf:Description rdf:about="http://localhost:8080/rest/foo">
+    <fedora:lastModifiedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bypassAdmin</fedora:lastModifiedBy>
+    <rdf:type rdf:resource="http://fedora.info/definitions/v4/repository#Resource"/>
+    <rdf:type rdf:resource="http://fedora.info/definitions/v4/repository#Container"/>
+    <fedora:lastModified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-08-29T20:05:57.109000+00:00</fedora:lastModified>
+    <fedora:writable rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</fedora:writable>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#Container"/>
+    <fedora:createdBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">bypassAdmin</fedora:createdBy>
+    <rdf:type rdf:resource="http://www.w3.org/ns/ldp#RDFSource"/>
+    <fedora:created rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-08-29T20:05:57.109000+00:00</fedora:created>
+    <fedora:hasParent rdf:resource="http://localhost:8080/rest/"/>
+  </rdf:Description>
+</rdf:RDF>
+```
+
 #### Create NonRDF (Binary) Resources
 
 FC4, and LDP instances in general, also have [NonRDFSource](https://www.w3.org/TR/ldp/#ldpnr) (Binary) resources.  These contain binary files.

--- a/pyfc4/models.py
+++ b/pyfc4/models.py
@@ -1383,6 +1383,10 @@ class Resource(object):
 				updated_self = self.repo.get_resource(self.uri)
 				self.binary.refresh(updated_self)
 
+		# fire optional post-update hook
+		if hasattr(self,'_post_update'):
+			self._post_update()
+
 		# determine refreshing
 		'''
 		If not updating binary, pass that bool to refresh as refresh_binary flag to avoid touching binary data

--- a/pyfc4/models.py
+++ b/pyfc4/models.py
@@ -166,7 +166,7 @@ class Repository(object):
 			- If 200, continues, 404, returns False, otherwise raises Exception
 			- Parse resource type
 				- If custom resource type parser provided, this fires
-				- Else, or if custom parser misses, parse LDP resource type
+				- Else, or if custom parser misses, fire HEAD request and parse LDP resource type from Link header
 			- Return instantiated pyfc4 resource 
 
 		Args:
@@ -184,6 +184,8 @@ class Repository(object):
 		# remove fcr:metadata if included, as handled below
 		if uri.toPython().endswith('/fcr:metadata'):
 			uri = rdflib.term.URIRef(uri.toPython().rstrip('/fcr:metadata'))
+
+
 
 		# fire GET request
 		get_response = self.api.http_request(
@@ -210,7 +212,9 @@ class Repository(object):
 				# parse LDP resource type from headers if custom resource parser misses, 
 				# or not provided
 				if not resource_type:
-					resource_type = self.api.parse_resource_type(get_response)
+					# Issue HEAD request to get LDP resource type from URI proper, not /fcr:metadata
+					head_response = self.api.http_request('HEAD', uri)
+					resource_type = self.api.parse_resource_type(head_response)
 
 			logger.debug('using resource type: %s' % resource_type)
 

--- a/pyfc4/models.py
+++ b/pyfc4/models.py
@@ -655,8 +655,16 @@ class SparqlUpdate(object):
 		# iterate through graphs and get unique namespace uris
 		for graph in [self.diffs.overlap, self.diffs.removed, self.diffs.added]:
 			for s,p,o in graph:
-				ns_prefix, ns_uri, predicate = graph.compute_qname(p)
-				self.update_namespaces.add(ns_uri)
+				try:
+					ns_prefix, ns_uri, predicate = graph.compute_qname(p) # predicates
+					self.update_namespaces.add(ns_uri)
+				except:
+					logger.debug('could not parse Object URI: %s' % ns_uri)
+				try:
+					ns_prefix, ns_uri, predicate = graph.compute_qname(o) # objects
+					self.update_namespaces.add(ns_uri)
+				except:
+					logger.debug('could not parse Object URI: %s' % ns_uri)
 		logger.debug(self.update_namespaces)
 
 		# build unique prefixes dictionary
@@ -851,7 +859,7 @@ class Resource(object):
 				if not serialization_format:
 					serialization_format = self.repo.default_serialization
 				data = self.rdf.graph.serialize(format=serialization_format)
-				logger.debug('Serialized graph used for resource creatoin:')
+				logger.debug('Serialized graph used for resource creation:')
 				logger.debug(data.decode('utf-8'))
 				self.headers['Content-Type'] = serialization_format
 			
@@ -1174,7 +1182,7 @@ class Resource(object):
 		and all local modifications are made to self.rdf.graph.  This method compares the two graphs and returns the diff
 		in the format of three graphs:
 
-			overlap - triples shared by both
+			overlap - triples SHARED by both
 			removed - triples that exist ONLY in the original graph, self.rdf._orig_graph
 			added - triples that exist ONLY in the modified graph, self.rdf.graph
 

--- a/pyfc4/plugins/pcdm/README.md
+++ b/pyfc4/plugins/pcdm/README.md
@@ -2,4 +2,6 @@
 
 ## Overview
 
+This plugin provides basic support for the [Portland Common Data Model (PCDM)](http://pcdm.org/).
+
 ## Basic Usage

--- a/pyfc4/plugins/pcdm/__init__.py
+++ b/pyfc4/plugins/pcdm/__init__.py
@@ -25,9 +25,9 @@ def custom_resource_type_parser(repo, uri, get_response):
 	logger.debug('found following rdf:types: %s' % rdf_types)
 
 	# look for pcdm:*
-	if 'http://pcdm.org/models#Collection' in rdf_types:
+	if rdflib.term.URIRef('http://pcdm.org/models#Collection') in rdf_types:
 		return models.PCDMCollection
-	elif 'http://pcdm.org/models#Object' in rdf_types:
+	elif rdflib.term.URIRef('http://pcdm.org/models#Object') in rdf_types:
 		return models.PCDMObject
 	# elif 'http://pcdm.org/models#File' in rdf_types:
 	# 	return models.PCDMFile

--- a/pyfc4/plugins/pcdm/__init__.py
+++ b/pyfc4/plugins/pcdm/__init__.py
@@ -1,3 +1,37 @@
 # pyfc4 plugin: pcdm
 
+import rdflib
+
 from pyfc4.plugins.pcdm import models, examples
+
+
+# logging
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def custom_resource_type_parser(repo, uri, get_response):
+
+	logger.debug("PCDM plugin, custom resource type parser firing")
+
+	# parse graph
+	resource_graph = repo.api.parse_rdf_payload(get_response.content, get_response.headers)
+
+	# get rdf:types, using get_response.url as the uri
+	rdf_types = list(resource_graph.objects(
+		uri,
+		rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')))
+	logger.debug('found following rdf:types: %s' % rdf_types)
+
+	# look for pcdm:*
+	if 'http://pcdm.org/models#Collection' in rdf_types:
+		return models.PCDMCollection
+	elif 'http://pcdm.org/models#Object' in rdf_types:
+		return models.PCDMObject
+	# elif 'http://pcdm.org/models#File' in rdf_types:
+	# 	return models.PCDMFile
+	else:
+		logger.debug('PCDM resource type not detected')
+		return False
+

--- a/pyfc4/plugins/pcdm/examples.py
+++ b/pyfc4/plugins/pcdm/examples.py
@@ -4,75 +4,24 @@
 from pyfc4 import models as _models
 
 # import pcdm models
-from pyfc4.plugins.pcdm import models
+from pyfc4.plugins import pcdm
 
 
 # function to create handful of PCDM related objects
 def create_pcdm_demo_resources(repo):
 
-	'''
-	Convenience function to create example hierarchy of PCDM resources.
-
-	Args:
-		repo (pyfc4.models.Repository): expects a repository instance
-	'''
-
-	# create root objcts /collections and /objects
-	collections = _models.BasicContainer(repo, models.collections_path)
-	collections.create(specify_uri=True)
-	objects = _models.BasicContainer(repo, models.objects_path)
-	objects.create(specify_uri=True)
-
-	# create sample colors collection
-	colors = models.PCDMCollection(repo, 'colors')
+	# create colors collection
+	colors = pcdm.models.PCDMCollection(repo, 'colors')
 	colors.create(specify_uri=True)
 
-	# create sample objects
-	red = colors.create_member_object('red', specify_uri=True)
-	green = colors.create_member_object('green', specify_uri=True)
-	blue = colors.create_member_object('blue', specify_uri=True)
-
-	# create children to green
-	lime = green.create_member_object('lime', specify_uri=True)
-	chartreuse = green.create_member_object('chartreuse', specify_uri=True)
-
-	# create poem for lime green
-	poem = lime.create_file('poem', specify_uri=True, data='you\'ve always been\ngood to me lime green', mimetype='text/plain')
-
-	# create related proxy object for lime
-	lime.create_related_proxy_object(chartreuse.uri,'chartreuse',specify_uri=True)
-
-	# create associated spectrum file for lime
-	lime.create_associated_file('spectrum',data='570nm',mimetype='text/plain',specify_uri=True)
-
-	# create collectoin without uri
-	generic_collection = models.PCDMCollection(repo)
-	generic_collection.create()
-
-	# create generic children
-	generic_child1 = generic_collection.create_member_object()
-	generic_child2 = generic_collection.create_member_object()
-	generic_child3 = generic_collection.create_member_object()
-
-	# create generic child to child1
-	generic_childA = generic_child1.create_member_object()
-
-	# create file for generic_childA
-	generic_file = generic_childA.create_file(data='We\'re in Delaware.', mimetype='text/plain')
+	# create color objects
+	green = pcdm.models.PCDMObject(repo, 'green')
+	green.create(specify_uri=True)
+	yellow = pcdm.models.PCDMObject(repo, 'yellow')
+	yellow.create(specify_uri=True)
 
 
 # function to delete /collections and /objects
 def delete_pcdm_demo_resources(repo):
 
-	'''
-	Convenience function to delete example hierarchy of PCDM resources.
-
-	Args:
-		repo (pyfc4.models.Repository): expects a repository instance
-	'''
-
-	collections = repo.get_resource('collections')
-	collections.delete()
-
-	objects = repo.get_resource('objects')
-	objects.delete()
+	pass

--- a/pyfc4/plugins/pcdm/examples.py
+++ b/pyfc4/plugins/pcdm/examples.py
@@ -20,6 +20,8 @@ def create_pcdm_demo_resources(repo):
 	yellow = pcdm.models.PCDMObject(repo, 'yellow')
 	yellow.create(specify_uri=True)
 
+	
+
 
 # function to delete /collections and /objects
 def delete_pcdm_demo_resources(repo):

--- a/pyfc4/plugins/pcdm/models.py
+++ b/pyfc4/plugins/pcdm/models.py
@@ -1,6 +1,7 @@
 # pyfc4 plugin: pcdm.models
 
 import copy
+import time
 
 # import pyfc4 base models
 from pyfc4 import models as _models

--- a/pyfc4/plugins/pcdm/models.py
+++ b/pyfc4/plugins/pcdm/models.py
@@ -45,10 +45,10 @@ class PCDMCollection(_models.BasicContainer):
 		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 
-	def __init__(self, repo, uri='', response=None, retrieve_pcdm_links=True):
+	def __init__(self, repo, uri=None, response=None, retrieve_pcdm_links=True):
 
 		# fire parent Container init()
-		super().__init__(repo, uri="%s/%s" % (collections_path, uri), response=response)
+		super().__init__(repo, uri=uri, response=response)
 
 		# members, related
 		self.members = self.get_members(retrieve=retrieve_pcdm_links)
@@ -60,7 +60,7 @@ class PCDMCollection(_models.BasicContainer):
 		'''
 		resource.create() hook
 
-		For PCDM Collections, post creation, also create 
+		For PCDM Collections, post creation, also create
 		'''
 
 		# create /members child resource
@@ -168,7 +168,7 @@ class PCDMObject(_models.BasicContainer):
 		response (requests.models.Response): defaults None, but if passed, populate self.data, self.headers, self.status_code
 	'''
 
-	def __init__(self, repo, uri='', response=None, retrieve_pcdm_links=True):
+	def __init__(self, repo, uri=None, response=None, retrieve_pcdm_links=True):
 
 		# fire parent Container init()
 		super().__init__(repo, uri=uri, response=response)
@@ -340,11 +340,7 @@ class PCDMProxyObject(_models.BasicContainer):
 		proxyFor (rdflib.term.URIRef,str): URI of resource this resource is a proxy in, sets ore:proxyIn triple
 	'''
 
-	def __init__(self, repo, uri='', response=None, proxyForURI=None, proxyInURI=None):
-
-		# if full URI provided, as is the case with retrieval, derive "short" URI
-		if repo.root in uri:
-			uri = uri.split(collections_path)[-1].lstrip('/')
+	def __init__(self, repo, uri=None, response=None, proxyForURI=None, proxyInURI=None):
 
 		# fire parent Container init()
 		super().__init__(repo, uri=uri, response=response)

--- a/pyfc4/plugins/pcdm/models.py
+++ b/pyfc4/plugins/pcdm/models.py
@@ -20,7 +20,6 @@ objects_path = 'objects'
 collections_path = 'collections'
 
 
-
 class PCDMCollection(_models.BasicContainer):
 
 	'''
@@ -51,25 +50,7 @@ class PCDMCollection(_models.BasicContainer):
 		# fire parent Container init()
 		super().__init__(repo, uri="%s/%s" % (collections_path, uri), response=response)
 
-		# members, related
-		self.members = []
-		self.related = []
-
-		# if exists, populate
-		if self.exists:
-			self.get_members()
-			self.get_related()
-
-
-	def get_members(self):
-
-		'''
-		method to retrieve resources from ../members, per PCDM in LDP recs
-		'''
-
-
-
-
+		
 	def _post_create(self):
 
 		'''
@@ -102,10 +83,6 @@ class PCDMCollection(_models.BasicContainer):
 	# 	'''
 	# 	overrides BasicContainer .delete, removing all associated resources
 	# 	'''
-
-
-
-
 
 
 class PCDMObject(_models.BasicContainer):
@@ -143,6 +120,83 @@ class PCDMObject(_models.BasicContainer):
 
 		# fire parent Container init()
 		super().__init__(repo, uri=uri, response=response)
+
+		# members, related
+		self.members = self.get_members()
+		self.files = self.get_files()
+		self.associated = self.get_associated()
+
+
+	def get_members(self, retrieve=False):
+
+		'''
+		get pcdm:hasMember for this resource, optionally retrieving resource payload
+
+		Args:
+			retrieve (bool): if True, issue .refresh() on resource thereby confirming existence and retrieving payload
+		'''
+
+		if self.exists and hasattr(self.rdf.triples.pcdm, 'hasMember'):
+			members = [ PCDMObject(self.repo, uri) for uri in self.rdf.triples.pcdm.hasMember ]
+
+			# if retrieve, perform retrieve through .refresh()
+			if retrieve:
+				for member in members:
+					member.refresh()
+
+			# return
+			return members
+
+		else:
+			return []
+
+
+	def get_files(self, retrieve=False):
+
+		'''
+		get pcdm:hasFile for this resource, optionally retrieving resource payload
+
+		Args:
+			retrieve (bool): if True, issue .refresh() on resource thereby confirming existence and retrieving payload
+		'''
+
+		if self.exists and hasattr(self.rdf.triples.pcdm, 'hasFile'):
+			files = [ _models.NonRDFSource(self.repo, uri) for uri in self.rdf.triples.pcdm.hasFile ]
+
+			# if retrieve, perform retrieve through .refresh()
+			if retrieve:
+				for file in files:
+					file.refresh()
+
+			# return
+			return files
+
+		else:
+			return []
+
+
+	def get_associated(self, retrieve=False):
+
+		'''
+		get pcdm:hasRelatedFile for this resource, optionally retrieving resource payload
+
+		Args:
+			retrieve (bool): if True, issue .refresh() on resource thereby confirming existence and retrieving payload
+		'''
+
+		if self.exists and hasattr(self.rdf.triples.pcdm, 'hasRelatedFile'):
+			files = [ _models.NonRDFSource(self.repo, uri) for uri in self.rdf.triples.pcdm.hasRelatedFile ]
+
+			# if retrieve, perform retrieve through .refresh()
+			if retrieve:
+				for file in files:
+					file.refresh()
+
+			# return
+			return files
+
+		else:
+			return []
 
 
 	def _post_create(self):

--- a/pyfc4/plugins/pcdm/models.py
+++ b/pyfc4/plugins/pcdm/models.py
@@ -15,13 +15,6 @@ Implementation of PCDM in LDP:
 https://docs.google.com/document/d/1RI8aX8XQEk-30-Ht-DaPF5nz_VtI1-eqxUuDvF3nhv0/edit#
 '''
 
-
-# configurations
-# TODO: https://github.com/ghukill/pyfc4/issues/76
-objects_path = 'objects'
-collections_path = 'collections'
-
-
 class PCDMCollection(_models.BasicContainer):
 
 	'''

--- a/pyfc4/plugins/pcdm/models.py
+++ b/pyfc4/plugins/pcdm/models.py
@@ -285,11 +285,6 @@ class PCDMObject(_models.BasicContainer):
 		if self.exists and hasattr(self.rdf.triples, 'pcdm') and hasattr(self.rdf.triples.pcdm, 'hasMember'):
 			members = [ self.repo.parse_uri(uri) for uri in self.rdf.triples.pcdm.hasMember ]
 
-			# if retrieve, perform retrieve through .refresh()
-			if retrieve:
-				for member in members:
-					member.refresh()
-
 			# return
 			return members
 
@@ -308,11 +303,6 @@ class PCDMObject(_models.BasicContainer):
 
 		if self.exists and hasattr(self.rdf.triples, 'pcdm') and hasattr(self.rdf.triples.pcdm, 'hasFile'):
 			files = [ self.repo.parse_uri(uri) for uri in self.rdf.triples.pcdm.hasFile ]
-
-			# if retrieve, perform retrieve through .refresh()
-			if retrieve:
-				for file in files:
-					file.refresh()
 
 			# return
 			return files
@@ -333,11 +323,6 @@ class PCDMObject(_models.BasicContainer):
 		if self.exists and hasattr(self.rdf.triples, 'pcdm') and hasattr(self.rdf.triples.pcdm, 'hasRelatedFile'):
 			files = [ self.repo.parse_uri(uri) for uri in self.rdf.triples.pcdm.hasRelatedFile ]
 
-			# if retrieve, perform retrieve through .refresh()
-			if retrieve:
-				for file in files:
-					file.refresh()
-
 			# return
 			return files
 
@@ -356,11 +341,6 @@ class PCDMObject(_models.BasicContainer):
 
 		if self.exists and hasattr(self.rdf.triples, 'ore') and hasattr(self.rdf.triples.ore, 'aggregates'):
 			related = [ self.repo.parse_uri(uri) for uri in self.rdf.triples.ore.aggregates ]
-
-			# if retrieve, perform retrieve through .refresh()
-			if retrieve:
-				for resource in related:
-					resource.refresh()
 
 			# return
 			return related

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -588,7 +588,7 @@ class TestMovingCopying(object):
 		ephem2 = repo.get_resource(ephem.move('%s/ephem2' % testing_container_uri))
 
 		# test
-		assert not ephem.exists
+		assert not repo.get_resource('%s/ephem' % testing_container_uri)
 		assert ephem2.exists
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -351,7 +351,7 @@ class TestBasicRelationship(object):
 
 		# confirm triples were added
 		for val in ['windy night','stormy seas']:
-			assert (foo.uri, foo.rdf.prefixes.dc.subject, rdflib.term.Literal(val, datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#string'))) in foo.rdf.graph
+			assert (foo.uri, foo.rdf.prefixes.dc.subject, rdflib.term.Literal(val)) in foo.rdf.graph
 
 
 	# set triple
@@ -373,7 +373,7 @@ class TestBasicRelationship(object):
 		foo.update()
 
 		# assert "one hit wonder"
-		assert (foo.uri, foo.rdf.prefixes.dc.title, rdflib.term.Literal('one hit wonder', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#string'))) in foo.rdf.graph
+		assert (foo.uri, foo.rdf.prefixes.dc.title, rdflib.term.Literal('one hit wonder')) in foo.rdf.graph
 
 
 	# remove triple
@@ -387,7 +387,7 @@ class TestBasicRelationship(object):
 		foo = repo.get_resource('%s/foo' % testing_container_uri)
 
 		# remove triple
-		foo.remove_triple(foo.rdf.prefixes.dc.subject, 'stormy seas')
+		foo.remove_triple(foo.rdf.prefixes.dc.subject, rdflib.term.Literal('stormy seas'))
 		foo.update()
 
 		assert not (foo.uri, foo.rdf.prefixes.dc.subject, rdflib.term.Literal('stormy seas')) in foo.rdf.graph
@@ -656,7 +656,7 @@ class TestVersions(object):
 		# add triple
 		foo.add_triple(foo.rdf.prefixes.dc.coverage, 'forest')
 		foo.update()
-		assert foo.rdf.triples.dc.coverage[0] == rdflib.term.Literal('forest', datatype=rdflib.term.URIRef('http://www.w3.org/2001/XMLSchema#string'))
+		assert foo.rdf.triples.dc.coverage[0] == rdflib.term.Literal('forest')
 
 		# get versions and revert to foo_v1 (pre triple)
 		foo.get_versions()


### PR DESCRIPTION
Large rework of PCDM plugin.  Instead of resources with methods to create children or related resources, follow the patterns of other Fedora libraries and assign already made resources to a resource.

Still needs tests and documentation, but PCDM relationships appear to working well.

Additionally, look into `FileSets` and `Work` from pcdm.org